### PR TITLE
Add testing lists

### DIFF
--- a/stage.ini
+++ b/stage.ini
@@ -19,10 +19,10 @@ allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exc
 output=moztestpub-track-digest256
 s3_key=e2etest/moztestpub-track-digest256
 
-#[entity-whitelist-testing]
-#entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-test-lists/master/trackwhite.json
-#output=moztestpub-trackwhite-digest256
-#s3_key=e2etest/moztestpub-trackwhite-digest256
+[entity-whitelist-testing]
+entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-test-lists/master/trackwhite.json
+output=moztestpub-trackwhite-digest256
+s3_key=e2etest/moztestpub-trackwhite-digest256
 
 [tracking-protection-abtest]
 allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list


### PR DESCRIPTION
I think this is all we need for:
- the A/B test to be run on the week of 2015-09-03
- the end-to-end testing of list updates

It requires these fixes to the list creation script:
- https://github.com/mozilla-services/shavar-list-creation/pull/21
- https://github.com/mozilla-services/shavar-list-creation/pull/20

and it doesn't attempt to address #2 or use our "disconnected" lists from #3.
