### PR TITLE
point stage creation at felipc repo

### DIFF
--- a/stage.ini
+++ b/stage.ini
@@ -76,32 +76,32 @@ s3_key=pluginblock/mozplugin2-block-digest256
 [flash-blocklist]
 output=block-flash-digest256
 s3_key=plugin-blocklist/block-flash-digest256
-blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flash.txt
+blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/master/flash.txt
 
 [flash-exceptions]
 output=except-flash-digest256
 s3_key=plugin-blocklist/except-flash-digest256
-blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashexceptions.txt
+blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/master/flashexceptions.txt
 
 [flash-allow]
 output=allow-flashallow-digest256
 s3_key=plugin-blocklist/allow-flashallow-digest256
-blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashallow.txt
+blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/master/flashallow.txt
 
 [flash-allow-exceptions]
 output=except-flashallow-digest256
 s3_key=plugin-blocklist/except-flashallow-digest256
-blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashallowexceptions.txt
+blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/master/flashallowexceptions.txt
 
 [flash-subdoc]
 output=block-flashsubdoc-digest256
 s3_key=plugin-blocklist/block-flashsubdoc-digest256
-blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashsubdoc.txt
+blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/master/flashsubdoc.txt
 
 [flash-subdoc-exceptions]
 output=except-flashsubdoc-digest256
 s3_key=plugin-blocklist/except-flashsubdoc-digest256
-blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashsubdocexceptions.txt
+blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/master/flashsubdocexceptions.txt
 
 [staging-entity-whitelist]
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-staging-lists/master/disconnect-entitylist.json


### PR DESCRIPTION
This will make the Shavar List Creation Stage job use felipc's branch, so that http://shavar.stage.mozaws.net/ serves his list contents instead of the production contents.