### PR TITLE
Revert "point stage config at felipc's week3 branch"

### DIFF
--- a/stage.ini
+++ b/stage.ini
@@ -76,32 +76,32 @@ s3_key=pluginblock/mozplugin2-block-digest256
 [flash-blocklist]
 output=block-flash-digest256
 s3_key=plugin-blocklist/block-flash-digest256
-blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/flashstudy-week3/flash.txt
+blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flash.txt
 
 [flash-exceptions]
 output=except-flash-digest256
 s3_key=plugin-blocklist/except-flash-digest256
-blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/flashstudy-week3/flashexceptions.txt
+blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashexceptions.txt
 
 [flash-allow]
 output=allow-flashallow-digest256
 s3_key=plugin-blocklist/allow-flashallow-digest256
-blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/flashstudy-week3/flashallow.txt
+blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashallow.txt
 
 [flash-allow-exceptions]
 output=except-flashallow-digest256
 s3_key=plugin-blocklist/except-flashallow-digest256
-blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/flashstudy-week3/flashallowexceptions.txt
+blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashallowexceptions.txt
 
 [flash-subdoc]
 output=block-flashsubdoc-digest256
 s3_key=plugin-blocklist/block-flashsubdoc-digest256
-blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/flashstudy-week3/flashsubdoc.txt
+blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashsubdoc.txt
 
 [flash-subdoc-exceptions]
 output=except-flashsubdoc-digest256
 s3_key=plugin-blocklist/except-flashsubdoc-digest256
-blocklist=https://raw.githubusercontent.com/felipc/shavar-plugin-blocklist/flashstudy-week3/flashsubdocexceptions.txt
+blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashsubdocexceptions.txt
 
 [staging-entity-whitelist]
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-staging-lists/master/disconnect-entitylist.json


### PR DESCRIPTION
This reverts commit 4f000a5fc80da81593ed97398b3e260b03979650.

Now that https://github.com/mozilla-services/shavar-plugin-blocklist/pull/11 is merged, we can revert this to point stage back at the main repo master branch.