### PR TITLE
bug 1371819: add flash-infobar-exceptions to prod

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -93,6 +93,11 @@ output=except-flashsubdoc-digest256
 s3_key=plugin-blocklist/except-flashsubdoc-digest256
 blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashsubdocexceptions.txt
 
+[flashinfobar-exceptions]
+output=except-flashinfobar-digest256
+s3_key=plugin-blocklist/except-flashinfobar-digest256
+blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashinfobar.txt
+
 [staging-entity-whitelist]
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-staging-lists/master/disconnect-entitylist.json
 output=mozstdstaging-trackwhite-digest256


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1371819#c4 ...

(This doesn't need a `lists2safebrowsing.py` change, because we already made that change for stage.)