### PR TITLE
Bug 1465528 - Add missing disconnect_categories on non-default lists

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -20,16 +20,19 @@ s3_key=tracking/basew3c-track-digest256
 
 # DNT="", content category only
 [tracking-protection-content]
+disconnect_categories=Content
 output=content-track-digest256
 s3_key=tracking/content-track-digest256
 
 # DNT="EFF", content category only
 [tracking-protection-contenteff]
+disconnect_categories=Content
 output=contenteff-track-digest256
 s3_key=tracking/contenteff-track-digest256
 
 # DNT="W3C", content category only
 [tracking-protection-contentw3c]
+disconnect_categories=Content
 output=contentw3c-track-digest256
 s3_key=tracking/contentw3c-track-digest256
 
@@ -61,6 +64,7 @@ output=mozstd-track-digest256
 s3_key=tracking/mozstd-track-digest256
 
 [tracking-protection-full]
+disconnect_categories=Advertising,Analytics,Social,Disconnect,Content
 output=mozfull-track-digest256
 s3_key=tracking/mozfull-track-digest256
 
@@ -119,5 +123,6 @@ output=mozstdstaging-track-digest256
 s3_key=tracking/mozstdstaging-track-digest256
 
 [staging-tracking-protection-full]
+disconnect_categories=Advertising,Analytics,Social,Disconnect,Content
 output=mozfullstaging-track-digest256
 s3_key=tracking/mozfullstaging-track-digest256


### PR DESCRIPTION
This is the same change as https://github.com/mozilla-services/shavar-list-creation-config/pull/28 but for `prod.ini`.