### PR TITLE
Bug 1459037 - Add Disconnect category to ads, analytics and social

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -38,19 +38,19 @@ s3_key=tracking/contentw3c-track-digest256
 
 # DNT="", ads category
 [tracking-protection-ads]
-disconnect_categories=Advertising
+disconnect_categories=Advertising,Disconnect
 output=ads-track-digest256
 s3_key=tracking/ads-track-digest256
 
 # DNT="", analytics category
 [tracking-protection-analytics]
-disconnect_categories=Analytics
+disconnect_categories=Analytics,Disconnect
 output=analytics-track-digest256
 s3_key=tracking/analytics-track-digest256
 
 # DNT="", social category
 [tracking-protection-social]
-disconnect_categories=Social
+disconnect_categories=Social,Disconnect
 output=social-track-digest256
 s3_key=tracking/social-track-digest256
 


### PR DESCRIPTION
This is the same as #29 but for `prod.ini`.