### PR TITLE
Update cryptomining config on stage

### DIFF
--- a/stage.ini
+++ b/stage.ini
@@ -174,14 +174,15 @@ disconnect_tags=fingerprinting
 output=content-fingerprinting-track-digest256
 s3_key=tracking/content-fingerprinting-track-digest256
 
-# DNT="", all top-level categories, cryptomining tag
+# DNT="", Cryptomining top-level category
 [tracking-protection-base-cryptomining]
-disconnect_tags=cryptominer
+disconnect_categories=Cryptomining
 output=base-cryptomining-track-digest256
 s3_key=tracking/base-cryptomining-track-digest256
 
-# DNT="", Content category, cryptomining tag
+# DNT="", Content top-level category and `cryptomining` tag
 [tracking-protection-content-cryptomining]
+disconnect_categories=Content
 disconnect_tags=cryptominer
 output=content-cryptomining-track-digest256
 s3_key=tracking/content-cryptomining-track-digest256


### PR DESCRIPTION
Update cryptomining config for new list format. This should also fix an issue where the content version of the cryptomining list was not actually scoped to the "Content" category.