### PR TITLE
Update stage.ini to include refactored category config and new fingerprinting config

### DIFF
--- a/stage.ini
+++ b/stage.ini
@@ -2,13 +2,8 @@
 default_disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 s3_upload=true
 s3_bucket=net-mozaws-stage-shavar-lists
-
-[tracking-protection-testing]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-test-lists/master/track.json
-output=moztestpub-track-digest256
-s3_key=trackingtest/moztestpub-track-digest256
-
 # DNT="", all categories except content category
+
 [tracking-protection-base]
 output=base-track-digest256
 s3_key=tracking/base-track-digest256
@@ -186,30 +181,30 @@ s3_key=tracking/content-cryptomining-track-digest256
 
 [fanboy-annoyance]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoyAnnoyance-blacklist.json
-disconnect_categories=fanBoyAnnoyance
+categories=fanBoyAnnoyance
 output=fanboyannoyance-ads-digest256
 s3_key=tracking/fanboyannoyance-ads-digest256
 
 [fanboy-social]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoySocial-blacklist.json
-disconnect_categories=fanBoySocial
+categories=fanBoySocial
 output=fanboysocial-ads-digest256
 s3_key=tracking/fanboysocial-ads-digest256
 
 [easylist]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/easyList-blacklist.json
-disconnect_categories=easyList
+categories=easyList
 output=easylist-ads-digest256
 s3_key=tracking/easylist-ads-digest256
 
 [easyprivacy]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/easyPrivacy-blacklist.json
-disconnect_categories=easyPrivacy
+categories=easyPrivacy
 output=easyprivacy-ads-digest256
 s3_key=tracking/easyprivacy-ads-digest256
 
 [adguard]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/adGuard-blacklist.json
-disconnect_categories=adGuard
+categories=adGuard
 output=adguard-ads-digest256
 s3_key=tracking/adguard-ads-digest256

--- a/stage.ini
+++ b/stage.ini
@@ -25,37 +25,37 @@ s3_key=tracking/basew3c-track-digest256
 
 # DNT="", content category only
 [tracking-protection-content]
-disconnect_categories=Content
+categories=Content
 output=content-track-digest256
 s3_key=tracking/content-track-digest256
 
 # DNT="EFF", content category only
 [tracking-protection-contenteff]
-disconnect_categories=Content
+categories=Content
 output=contenteff-track-digest256
 s3_key=tracking/contenteff-track-digest256
 
 # DNT="W3C", content category only
 [tracking-protection-contentw3c]
-disconnect_categories=Content
+categories=Content
 output=contentw3c-track-digest256
 s3_key=tracking/contentw3c-track-digest256
 
 # DNT="", ads category
 [tracking-protection-ads]
-disconnect_categories=Advertising,Disconnect
+categories=Advertising|Disconnect
 output=ads-track-digest256
 s3_key=tracking/ads-track-digest256
 
 # DNT="", analytics category
 [tracking-protection-analytics]
-disconnect_categories=Analytics,Disconnect
+categories=Analytics|Disconnect
 output=analytics-track-digest256
 s3_key=tracking/analytics-track-digest256
 
 # DNT="", social category
 [tracking-protection-social]
-disconnect_categories=Social,Disconnect
+categories=Social|Disconnect
 output=social-track-digest256
 s3_key=tracking/social-track-digest256
 
@@ -74,7 +74,7 @@ output=mozstd-track-digest256
 s3_key=tracking/mozstd-track-digest256
 
 [tracking-protection-full]
-disconnect_categories=Advertising,Analytics,Social,Disconnect,Content
+categories=Advertising|Analytics|Social|Disconnect|Content
 output=mozfull-track-digest256
 s3_key=tracking/mozfull-track-digest256
 
@@ -133,7 +133,7 @@ output=mozstdstaging-track-digest256
 s3_key=tracking/mozstdstaging-track-digest256
 
 [staging-tracking-protection-full]
-disconnect_categories=Advertising,Analytics,Social,Disconnect,Content
+categories=Advertising|Analytics|Social|Disconnect|Content
 output=mozfullstaging-track-digest256
 s3_key=tracking/mozfullstaging-track-digest256
 
@@ -162,28 +162,24 @@ blocklist_url=https://raw.githubusercontent.com/mozilla-services/shavar-experime
 output=fastblock3-track-digest256
 s3_key=fastblock/fastblock3-track-digest256
 
-# DNT="", all top-level categories, fingerprinting tag
 [tracking-protection-base-fingerprinting]
-disconnect_tags=fingerprinting
+categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256
 s3_key=tracking/base-fingerprinting-track-digest256
 
-# DNT="", Content category, fingerprinting tag
 [tracking-protection-content-fingerprinting]
-disconnect_categories=Content
-disconnect_tags=fingerprinting
+categories=Fingerprinting
+excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
 s3_key=tracking/content-fingerprinting-track-digest256
 
-# DNT="", Cryptomining top-level category
 [tracking-protection-base-cryptomining]
-disconnect_categories=Cryptomining
+categories=Cryptomining
 output=base-cryptomining-track-digest256
 s3_key=tracking/base-cryptomining-track-digest256
 
-# DNT="", Content top-level category and `cryptomining` tag
 [tracking-protection-content-cryptomining]
-disconnect_categories=Content
+categories=Content
 disconnect_tags=cryptominer
 output=content-cryptomining-track-digest256
 s3_key=tracking/content-cryptomining-track-digest256


### PR DESCRIPTION
This updates `stage.ini` to reflect the changes made in https://github.com/mozilla-services/shavar-list-creation/pull/73.

This updates the two fingerprinting lists, such that the `base-` list includes domains considered to be trackers and to fingerprint and the `content-` lists includes non-tracking fingerprinting domains.

In addition I removed `[tracking-protection-testing]`. This uses an old list that's incompatible with the new parser, and is not used in prod. I think it's safe to say we're no longer testing that list.