### PR TITLE
Update prod config for refactor

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -20,37 +20,37 @@ s3_key=tracking/basew3c-track-digest256
 
 # DNT="", content category only
 [tracking-protection-content]
-disconnect_categories=Content
+categories=Content
 output=content-track-digest256
 s3_key=tracking/content-track-digest256
 
 # DNT="EFF", content category only
 [tracking-protection-contenteff]
-disconnect_categories=Content
+categories=Content
 output=contenteff-track-digest256
 s3_key=tracking/contenteff-track-digest256
 
 # DNT="W3C", content category only
 [tracking-protection-contentw3c]
-disconnect_categories=Content
+categories=Content
 output=contentw3c-track-digest256
 s3_key=tracking/contentw3c-track-digest256
 
 # DNT="", ads category
 [tracking-protection-ads]
-disconnect_categories=Advertising,Disconnect
+categories=Advertising|Disconnect
 output=ads-track-digest256
 s3_key=tracking/ads-track-digest256
 
 # DNT="", analytics category
 [tracking-protection-analytics]
-disconnect_categories=Analytics,Disconnect
+categories=Analytics|Disconnect
 output=analytics-track-digest256
 s3_key=tracking/analytics-track-digest256
 
 # DNT="", social category
 [tracking-protection-social]
-disconnect_categories=Social,Disconnect
+categories=Social|Disconnect
 output=social-track-digest256
 s3_key=tracking/social-track-digest256
 
@@ -64,7 +64,7 @@ output=mozstd-track-digest256
 s3_key=tracking/mozstd-track-digest256
 
 [tracking-protection-full]
-disconnect_categories=Advertising,Analytics,Social,Disconnect,Content
+categories=Advertising|Analytics|Social|Disconnect|Content
 output=mozfull-track-digest256
 s3_key=tracking/mozfull-track-digest256
 
@@ -123,7 +123,7 @@ output=mozstdstaging-track-digest256
 s3_key=tracking/mozstdstaging-track-digest256
 
 [staging-tracking-protection-full]
-disconnect_categories=Advertising,Analytics,Social,Disconnect,Content
+categories=Advertising|Analytics|Social|Disconnect|Content
 output=mozfullstaging-track-digest256
 s3_key=tracking/mozfullstaging-track-digest256
 
@@ -152,58 +152,56 @@ blocklist_url=https://raw.githubusercontent.com/mozilla-services/shavar-experime
 output=fastblock3-track-digest256
 s3_key=fastblock/fastblock3-track-digest256
 
-# DNT="", all top-level categories, fingerprinting tag
 [tracking-protection-base-fingerprinting]
-disconnect_tags=fingerprinting
+categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256
 s3_key=tracking/base-fingerprinting-track-digest256
 
-# DNT="", Content category, fingerprinting tag
 [tracking-protection-content-fingerprinting]
-disconnect_categories=Content
-disconnect_tags=fingerprinting
+categories=Fingerprinting
+excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
 s3_key=tracking/content-fingerprinting-track-digest256
 
 # DNT="", Cryptomining top-level category
 [tracking-protection-base-cryptomining]
-disconnect_categories=Cryptomining
+categories=Cryptomining
 output=base-cryptomining-track-digest256
 s3_key=tracking/base-cryptomining-track-digest256
 
 # DNT="", Content top-level category and `cryptomining` tag
 [tracking-protection-content-cryptomining]
-disconnect_categories=Content
+categories=Content
 disconnect_tags=cryptominer
 output=content-cryptomining-track-digest256
 s3_key=tracking/content-cryptomining-track-digest256
 
 [fanboy-annoyance]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoyAnnoyance-blacklist.json
-disconnect_categories=fanBoyAnnoyance
+categories=fanBoyAnnoyance
 output=fanboyannoyance-ads-digest256
 s3_key=tracking/fanboyannoyance-ads-digest256
 
 [fanboy-social]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoySocial-blacklist.json
-disconnect_categories=fanBoySocial
+categories=fanBoySocial
 output=fanboysocial-ads-digest256
 s3_key=tracking/fanboysocial-ads-digest256
 
 [easylist]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/easyList-blacklist.json
-disconnect_categories=easyList
+categories=easyList
 output=easylist-ads-digest256
 s3_key=tracking/easylist-ads-digest256
 
 [easyprivacy]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/easyPrivacy-blacklist.json
-disconnect_categories=easyPrivacy
+categories=easyPrivacy
 output=easyprivacy-ads-digest256
 s3_key=tracking/easyprivacy-ads-digest256
 
 [adguard]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/adGuard-blacklist.json
-disconnect_categories=adGuard
+categories=adGuard
 output=adguard-ads-digest256
 s3_key=tracking/adguard-ads-digest256


### PR DESCRIPTION
Updates for changes made in https://github.com/mozilla-services/shavar-list-creation/pull/76

Output from a local run:
```
------ tracking-protection-base ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect'] matched 1879 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-base): publishing 1879 items; file size 60150

------ tracking-protection-baseeff ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect'] matched 1879 domains
 * found 1 rule(s) with DNT filter eff. Filtered output to 1
Tracking protection(tracking-protection-baseeff): publishing 2 items; file size 83

------ tracking-protection-basew3c ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect'] matched 1879 domains
 * found 0 rule(s) with DNT filter w3c. Filtered output to 0
Tracking protection(tracking-protection-basew3c): publishing 1 items; file size 51

------ tracking-protection-content ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Content'] matched 519 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-content): publishing 518 items; file size 16598

------ tracking-protection-contenteff ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Content'] matched 519 domains
 * found 1 rule(s) with DNT filter eff. Filtered output to 0
Tracking protection(tracking-protection-contenteff): publishing 1 items; file size 51

------ tracking-protection-contentw3c ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Content'] matched 519 domains
 * found 0 rule(s) with DNT filter w3c. Filtered output to 0
Tracking protection(tracking-protection-contentw3c): publishing 1 items; file size 51

------ tracking-protection-ads ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Disconnect'] matched 1538 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-ads): publishing 1539 items; file size 49270

------ tracking-protection-analytics ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Analytics', 'Disconnect'] matched 281 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-analytics): publishing 281 items; file size 9013

------ tracking-protection-social ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Social', 'Disconnect'] matched 62 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-social): publishing 63 items; file size 2037
Entity whitelist(entity-whitelist): publishing 9305 items; file size 297783

------ tracking-protection-standard ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect'] matched 1879 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-standard): publishing 1879 items; file size 60150

------ tracking-protection-full ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect', 'Content'] matched 2398 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-full): publishing 2396 items; file size 76694
Plugin blocklist(plugin-blocklist): publishing 94 items; file size 3029
Plugin blocklist(plugin-blocklist-experiment): publishing 132 items; file size 4245
Plugin blocklist(flash-blocklist): publishing 207 items; file size 6645
Plugin blocklist(flash-exceptions): publishing 2 items; file size 83
Plugin blocklist(flash-allow): publishing 1 items; file size 51
Plugin blocklist(flash-allow-exceptions): publishing 1 items; file size 51
Plugin blocklist(flash-subdoc): publishing 2293 items; file size 73398
Plugin blocklist(flash-subdoc-exceptions): publishing 3 items; file size 115
Plugin blocklist(flashinfobar-exceptions): publishing 10 items; file size 340
Entity whitelist(staging-entity-whitelist): publishing 9723 items; file size 311159

------ staging-tracking-protection-standard ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect'] matched 1879 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(staging-tracking-protection-standard): publishing 1879 items; file size 60150

------ staging-tracking-protection-full ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect', 'Content'] matched 2398 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(staging-tracking-protection-full): publishing 2396 items; file size 76694

------ fastblock1 ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-experiments/master/fastblock1.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect'] matched 1745 domains
 * removing 1 rule(s) due to DNT exceptions
Fastblock(fastblock1): publishing 1745 items; file size 55862
Fastblock whitelist(fastblock1-whitelist): publishing 607 items; file size 19446

------ fastblock2 ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-experiments/master/fastblock2.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect'] matched 1774 domains
 * removing 1 rule(s) due to DNT exceptions
Fastblock(fastblock2): publishing 1774 items; file size 56790
Fastblock whitelist(fastblock2-whitelist): publishing 4028 items; file size 128919

------ fastblock3 ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-experiments/master/fastblock3.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Disconnect'] matched 1767 domains
 * removing 1 rule(s) due to DNT exceptions
Fastblock(fastblock3): publishing 1767 items; file size 56566

------ tracking-protection-base-fingerprinting ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Advertising', 'Analytics', 'Social', 'Content'] matched 2398 domains
 * filter ['Fingerprinting'] matched 39 domains. Reduced set to 29 items.
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-base-fingerprinting): publishing 30 items; file size 980

------ tracking-protection-content-fingerprinting ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Fingerprinting'] matched 39 domains
 * filter ['Advertising', 'Analytics', 'Social', 'Content'] matched 2398 domains
 * exclusion filters removed 29 domains from output
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-content-fingerprinting): publishing 11 items; file size 372

------ tracking-protection-base-cryptomining ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Cryptomining'] matched 66 domains
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-base-cryptomining): publishing 67 items; file size 2165

------ tracking-protection-content-cryptomining ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Content'] matched 519 domains
 * removing 1 rule(s) due to DNT exceptions
 * found 0 rule(s) with filter set(['cryptominer']). Filtered output to 0.
Tracking protection(tracking-protection-content-cryptomining): publishing 1 items; file size 51

------ fanboy-annoyance ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoyAnnoyance-blacklist.json)
 * filter ['fanBoyAnnoyance'] matched 1002 domains
 * removing 0 rule(s) due to DNT exceptions
Tracking protection(fanboy-annoyance): publishing 1000 items; file size 32022

------ fanboy-social ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoySocial-blacklist.json)
 * filter ['fanBoySocial'] matched 334 domains
 * removing 0 rule(s) due to DNT exceptions
Tracking protection(fanboy-social): publishing 333 items; file size 10678

------ easylist ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/easyList-blacklist.json)
 * filter ['easyList'] matched 22744 domains
 * removing 0 rule(s) due to DNT exceptions
Tracking protection(easylist): publishing 22742 items; file size 727767

------ easyprivacy ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/easyPrivacy-blacklist.json)
 * filter ['easyPrivacy'] matched 9489 domains
 * removing 0 rule(s) due to DNT exceptions
Tracking protection(easyprivacy): publishing 9482 items; file size 303447

------ adguard ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/adGuard-blacklist.json)
 * filter ['adGuard'] matched 899 domains
 * removing 0 rule(s) due to DNT exceptions
Tracking protection(adguard): publishing 900 items; file size 28822
```