### PR TITLE
Add config for Remote Settings

### DIFF
--- a/stage.ini
+++ b/stage.ini
@@ -2,6 +2,12 @@
 default_disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 s3_upload=true
 s3_bucket=net-mozaws-stage-shavar-lists
+remote_settings_upload=false
+remote_settings_bucket=main-workspace
+remote_settings_collection=tracking-protection-lists
+remote_settings_url=%(SHAVAR_REMOTE_SETTINGS_URL)s
+remote_settings_username=%(SHAVAR_REMOTE_SETTINGS_USERNAME)s
+remote_settings_password=%(SHAVAR_REMOTE_SETTINGS_PASSWORD)s
 # DNT="", all categories except content category
 
 [tracking-protection-base]

--- a/stage.ini
+++ b/stage.ini
@@ -114,6 +114,7 @@ s3_key=tracking/mozfull-track-digest256
 [plugin-blocklist]
 output=mozplugin-block-digest256
 s3_key=plugin-blocklist/mozplugin-block-digest256
+remote_settings_upload=true
 blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/mozplugin-block.txt
 
 [plugin-blocklist-experiment]
@@ -189,6 +190,7 @@ s3_key=fastblock/fastblock2-track-digest256
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-experiments/master/fastblock2-whitelist.json
 output=fastblock2-trackwhite-digest256
 s3_key=fastblock/fastblock2-trackwhite-digest256
+remote_settings_upload=true
 
 [fastblock3]
 blocklist_url=https://raw.githubusercontent.com/mozilla-services/shavar-experiments/master/fastblock3.json
@@ -205,6 +207,7 @@ categories=Fingerprinting
 excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
 s3_key=tracking/content-fingerprinting-track-digest256
+remote_settings_upload=true
 
 [tracking-protection-base-cryptomining]
 categories=Cryptomining


### PR DESCRIPTION
# About this PR
After completing https://github.com/mozilla-services/shavar-list-creation/pull/85 `shavar-list-creation` can publish safebrowsing formatted tracking lists to Remote Settings based on configurations.
- [ ] Remote Settings configurations are included in `stage.ini`:
- Remote Settings upload: default value, either true or false, indicating if list should be published to Remote Settings
- Remote Settings bucket name: the bucket the collection `tracking-protection-lists` is stored in
- Remote Settings collection name: the collection that stores each records of safebrowsing formatted tracking list
- Remote Settings url
- Remote Settings username
- Remote Settings password
- [ ] Configuration for testing Remote Settings are included in `stage.ini`:
- `content-fingerprinting-track-digest256`: type of list is `Tracker` and has both categories and excluded categories
- `mozplugin-block-digest256`: type of list is `Plugin` should have no categories and excluded categories
- `fastblock2-trackwhite-digest256`: type of list is `Entity` should have no categories and excluded categories