### PR TITLE
Add versioning config

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -7,6 +7,7 @@ s3_upload=true
 [tracking-protection-base]
 output=base-track-digest256
 s3_key=tracking/base-track-digest256
+versioning_needed=true
 
 # DNT="EFF", all categories except content category
 [tracking-protection-baseeff]
@@ -23,6 +24,7 @@ s3_key=tracking/basew3c-track-digest256
 categories=Content
 output=content-track-digest256
 s3_key=tracking/content-track-digest256
+versioning_needed=true
 
 # DNT="EFF", content category only
 [tracking-protection-contenteff]
@@ -41,18 +43,21 @@ s3_key=tracking/contentw3c-track-digest256
 categories=Advertising|Disconnect
 output=ads-track-digest256
 s3_key=tracking/ads-track-digest256
+versioning_needed=true
 
 # DNT="", analytics category
 [tracking-protection-analytics]
 categories=Analytics|Disconnect
 output=analytics-track-digest256
 s3_key=tracking/analytics-track-digest256
+versioning_needed=true
 
 # DNT="", social category
 [tracking-protection-social]
 categories=Social|Disconnect
 output=social-track-digest256
 s3_key=tracking/social-track-digest256
+versioning_needed=true
 
 # These "social-tracking-protection" lists are for Firefox STP
 [social-tracking-protection]
@@ -60,30 +65,35 @@ disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-li
 categories=Facebook|Twitter|LinkedIn
 output=social-tracking-protection-digest256
 s3_key=tracking/social-tracking-protection-digest256
+versioning_needed=true
 
 [social-tracking-protection-facebook]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Facebook
 output=social-tracking-protection-facebook-digest256
 s3_key=tracking/social-tracking-protection-facebook-digest256
+versioning_needed=true
 
 [social-tracking-protection-twitter]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Twitter
 output=social-tracking-protection-twitter-digest256
 s3_key=tracking/social-tracking-protection-twitter-digest256
+versioning_needed=true
 
 [social-tracking-protection-linkedin]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=LinkedIn
 output=social-tracking-protection-linkedin-digest256
 s3_key=tracking/social-tracking-protection-linkedin-digest256
+versioning_needed=true
 
 [social-tracking-protection-youtube]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=YouTube
 output=social-tracking-protection-youtube-digest256
 s3_key=tracking/social-tracking-protection-youtube-digest256
+versioning_needed=true
 
 [entity-whitelist]
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-entitylist.json
@@ -187,18 +197,21 @@ s3_key=fastblock/fastblock3-track-digest256
 categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256
 s3_key=tracking/base-fingerprinting-track-digest256
+versioning_needed=true
 
 [tracking-protection-content-fingerprinting]
 categories=Fingerprinting
 excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
 s3_key=tracking/content-fingerprinting-track-digest256
+versioning_needed=true
 
 # DNT="", Cryptomining top-level category
 [tracking-protection-base-cryptomining]
 categories=Cryptomining
 output=base-cryptomining-track-digest256
 s3_key=tracking/base-cryptomining-track-digest256
+versioning_needed=true
 
 # DNT="", Content top-level category and `cryptomining` tag
 [tracking-protection-content-cryptomining]
@@ -206,6 +219,7 @@ categories=Content
 disconnect_tags=cryptominer
 output=content-cryptomining-track-digest256
 s3_key=tracking/content-cryptomining-track-digest256
+versioning_needed=true
 
 [fanboy-annoyance]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoyAnnoyance-blacklist.json

--- a/prod.ini
+++ b/prod.ini
@@ -7,7 +7,6 @@ s3_upload=true
 [tracking-protection-base]
 output=base-track-digest256
 s3_key=tracking/base-track-digest256
-versioning_needed=true
 
 # DNT="EFF", all categories except content category
 [tracking-protection-baseeff]
@@ -24,7 +23,6 @@ s3_key=tracking/basew3c-track-digest256
 categories=Content
 output=content-track-digest256
 s3_key=tracking/content-track-digest256
-versioning_needed=true
 
 # DNT="EFF", content category only
 [tracking-protection-contenteff]
@@ -43,21 +41,18 @@ s3_key=tracking/contentw3c-track-digest256
 categories=Advertising|Disconnect
 output=ads-track-digest256
 s3_key=tracking/ads-track-digest256
-versioning_needed=true
 
 # DNT="", analytics category
 [tracking-protection-analytics]
 categories=Analytics|Disconnect
 output=analytics-track-digest256
 s3_key=tracking/analytics-track-digest256
-versioning_needed=true
 
 # DNT="", social category
 [tracking-protection-social]
 categories=Social|Disconnect
 output=social-track-digest256
 s3_key=tracking/social-track-digest256
-versioning_needed=true
 
 # These "social-tracking-protection" lists are for Firefox STP
 [social-tracking-protection]
@@ -65,35 +60,30 @@ disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-li
 categories=Facebook|Twitter|LinkedIn
 output=social-tracking-protection-digest256
 s3_key=tracking/social-tracking-protection-digest256
-versioning_needed=true
 
 [social-tracking-protection-facebook]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Facebook
 output=social-tracking-protection-facebook-digest256
 s3_key=tracking/social-tracking-protection-facebook-digest256
-versioning_needed=true
 
 [social-tracking-protection-twitter]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Twitter
 output=social-tracking-protection-twitter-digest256
 s3_key=tracking/social-tracking-protection-twitter-digest256
-versioning_needed=true
 
 [social-tracking-protection-linkedin]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=LinkedIn
 output=social-tracking-protection-linkedin-digest256
 s3_key=tracking/social-tracking-protection-linkedin-digest256
-versioning_needed=true
 
 [social-tracking-protection-youtube]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=YouTube
 output=social-tracking-protection-youtube-digest256
 s3_key=tracking/social-tracking-protection-youtube-digest256
-versioning_needed=true
 
 [entity-whitelist]
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-entitylist.json
@@ -197,21 +187,18 @@ s3_key=fastblock/fastblock3-track-digest256
 categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256
 s3_key=tracking/base-fingerprinting-track-digest256
-versioning_needed=true
 
 [tracking-protection-content-fingerprinting]
 categories=Fingerprinting
 excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
 s3_key=tracking/content-fingerprinting-track-digest256
-versioning_needed=true
 
 # DNT="", Cryptomining top-level category
 [tracking-protection-base-cryptomining]
 categories=Cryptomining
 output=base-cryptomining-track-digest256
 s3_key=tracking/base-cryptomining-track-digest256
-versioning_needed=true
 
 # DNT="", Content top-level category and `cryptomining` tag
 [tracking-protection-content-cryptomining]
@@ -219,7 +206,6 @@ categories=Content
 disconnect_tags=cryptominer
 output=content-cryptomining-track-digest256
 s3_key=tracking/content-cryptomining-track-digest256
-versioning_needed=true
 
 [fanboy-annoyance]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoyAnnoyance-blacklist.json

--- a/stage.ini
+++ b/stage.ini
@@ -13,6 +13,7 @@ remote_settings_password=%(SHAVAR_REMOTE_SETTINGS_PASSWORD)s
 [tracking-protection-base]
 output=base-track-digest256
 s3_key=tracking/base-track-digest256
+versioning_needed=true
 
 # DNT="EFF", all categories except content category
 [tracking-protection-baseeff]
@@ -29,6 +30,7 @@ s3_key=tracking/basew3c-track-digest256
 categories=Content
 output=content-track-digest256
 s3_key=tracking/content-track-digest256
+versioning_needed=true
 
 # DNT="EFF", content category only
 [tracking-protection-contenteff]
@@ -47,12 +49,14 @@ s3_key=tracking/contentw3c-track-digest256
 categories=Advertising|Disconnect
 output=ads-track-digest256
 s3_key=tracking/ads-track-digest256
+versioning_needed=true
 
 # DNT="", analytics category
 [tracking-protection-analytics]
 categories=Analytics|Disconnect
 output=analytics-track-digest256
 s3_key=tracking/analytics-track-digest256
+versioning_needed=true
 
 # DNT="", social category
 # NOTE: This is the *Disconnect* Social category; not the same as STP below
@@ -60,6 +64,7 @@ s3_key=tracking/analytics-track-digest256
 categories=Social|Disconnect
 output=social-track-digest256
 s3_key=tracking/social-track-digest256
+versioning_needed=true
 
 # These "social-tracking-protection" lists are for Firefox STP
 [social-tracking-protection]
@@ -67,30 +72,35 @@ disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-li
 categories=Facebook|Twitter|LinkedIn
 output=social-tracking-protection-digest256
 s3_key=tracking/social-tracking-protection-digest256
+versioning_needed=true
 
 [social-tracking-protection-facebook]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Facebook
 output=social-tracking-protection-facebook-digest256
 s3_key=tracking/social-tracking-protection-facebook-digest256
+versioning_needed=true
 
 [social-tracking-protection-twitter]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Twitter
 output=social-tracking-protection-twitter-digest256
 s3_key=tracking/social-tracking-protection-twitter-digest256
+versioning_needed=true
 
 [social-tracking-protection-linkedin]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=LinkedIn
 output=social-tracking-protection-linkedin-digest256
 s3_key=tracking/social-tracking-protection-linkedin-digest256
+versioning_needed=true
 
 [social-tracking-protection-youtube]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=YouTube
 output=social-tracking-protection-youtube-digest256
 s3_key=tracking/social-tracking-protection-youtube-digest256
+versioning_needed=true
 
 [entity-whitelist]
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-entitylist.json
@@ -201,6 +211,7 @@ s3_key=fastblock/fastblock3-track-digest256
 categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256
 s3_key=tracking/base-fingerprinting-track-digest256
+versioning_needed=true
 
 [tracking-protection-content-fingerprinting]
 categories=Fingerprinting
@@ -208,17 +219,20 @@ excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
 s3_key=tracking/content-fingerprinting-track-digest256
 remote_settings_upload=true
+versioning_needed=true
 
 [tracking-protection-base-cryptomining]
 categories=Cryptomining
 output=base-cryptomining-track-digest256
 s3_key=tracking/base-cryptomining-track-digest256
+versioning_needed=true
 
 [tracking-protection-content-cryptomining]
 categories=Content
 disconnect_tags=cryptominer
 output=content-cryptomining-track-digest256
 s3_key=tracking/content-cryptomining-track-digest256
+versioning_needed=true
 
 [fanboy-annoyance]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/fanBoyAnnoyance-blacklist.json


### PR DESCRIPTION
# About this PR
https://github.com/mozilla-services/shavar-list-creation/pull/92 adds functionality to version lists based on different list available in versioned branches on [Shavar prod lists repo](https://github.com/mozilla-services/shavar-prod-lists) as requested in https://github.com/mozilla-services/shavar-list-creation/issues/90. This PR adds the configuration to enable versioning.

# Acceptance Criteria
The following lists should have `versioning_needed` set to `true` to enable creation and publishing of the versioned lists when `shavar-list-creation` is ran.
- base-track-digest256
- content-track-digest256
- ads-track-digest256
- analytics-track-digest256
- social-track-digest256
- base-fingerprinting-track-digest256
- content-fingerprinting-track-digest256
- base-cryptomining-track-digest256
- content-cryptomining-track-digest256
- social-tracking-protection-digest256
- social-tracking-protection-facebook-digest256
- social-tracking-protection-twitter-digest256
- social-tracking-protection-linkedin-digest256
- social-tracking-protection-youtube-digest256
