### PR TITLE
Add versioning to entity lists on Staging environment

### DIFF
--- a/stage.ini
+++ b/stage.ini
@@ -106,6 +106,13 @@ versioning_needed=true
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-entitylist.json
 output=mozstd-trackwhite-digest256
 s3_key=entity/mozstd-trackwhite-digest256
+versioning_needed=true
+
+[google-whitelist]
+entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-entitylist.json
+output=google-trackwhite-digest256
+s3_key=entity/google-trackwhite-digest256
+versioning_needed=true
 
 [entity-whitelist-testing]
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-test-lists/master/trackwhite.json


### PR DESCRIPTION
# About this PR
This configuration is needed to test that mozstd-trackwhite-digest256 and google-trackwhite-digest256 are versioned in Staging of shavar-list-creation