### PR TITLE
Add versioning to entity lists on Production environment

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -101,6 +101,12 @@ output=mozstd-trackwhite-digest256
 s3_key=entity/mozstd-trackwhite-digest256
 versioning_needed=true
 
+[google-whitelist]
+entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-entitylist.json
+output=google-trackwhite-digest256
+s3_key=entity/google-trackwhite-digest256
+versioning_needed=true
+
 [tracking-protection-standard]
 output=mozstd-track-digest256
 s3_key=tracking/mozstd-track-digest256

--- a/prod.ini
+++ b/prod.ini
@@ -99,6 +99,7 @@ versioning_needed=true
 entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-entitylist.json
 output=mozstd-trackwhite-digest256
 s3_key=entity/mozstd-trackwhite-digest256
+versioning_needed=true
 
 [tracking-protection-standard]
 output=mozstd-track-digest256


### PR DESCRIPTION
# About this PR
This configuration is needed to enable versioning on mozstd-trackwhite-digest256 and google-trackwhite-digest256 on prod.

##
Dependent on successful testing on Stage using https://github.com/mozilla-services/shavar-list-creation-config/pull/58