### PR TITLE
Replace cryptomining tag with category

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -195,10 +195,9 @@ output=base-cryptomining-track-digest256
 s3_key=tracking/base-cryptomining-track-digest256
 versioning_needed=true
 
-# DNT="", Content top-level category and `cryptomining` tag
+# DNT="", Content and Cryptomining top-level categories
 [tracking-protection-content-cryptomining]
-categories=Content
-disconnect_tags=cryptominer
+categories=Content,Cryptomining
 output=content-cryptomining-track-digest256
 s3_key=tracking/content-cryptomining-track-digest256
 versioning_needed=true

--- a/stage.ini
+++ b/stage.ini
@@ -209,8 +209,7 @@ s3_key=tracking/base-cryptomining-track-digest256
 versioning_needed=true
 
 [tracking-protection-content-cryptomining]
-categories=Content
-disconnect_tags=cryptominer
+categories=Content,Cryptomining
 output=content-cryptomining-track-digest256
 s3_key=tracking/content-cryptomining-track-digest256
 versioning_needed=true


### PR DESCRIPTION
Remove the deprecated "cryptominer" tag from `stage.ini` and `prod.ini` and use the "Cryptomining" category instead. 
However, we might prefer to remove the `[tracking-protection-content-cryptomining]` section completely. The corresponding list contains only the dummytracker domains. @say-yawn, is this list used?

Addresses https://github.com/mozilla-services/shavar-list-creation/issues/149