### PR TITLE
Remove unused lists from configurations

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -161,11 +161,6 @@ output=except-flashinfobar-digest256
 s3_key=plugin-blocklist/except-flashinfobar-digest256
 blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashinfobar.txt
 
-[staging-entity-whitelist]
-entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-staging-lists/master/disconnect-entitylist.json
-output=mozstdstaging-trackwhite-digest256
-s3_key=entity/mozstdstaging-trackwhite-digest256
-
 [staging-tracking-protection-standard]
 output=mozstdstaging-track-digest256
 s3_key=tracking/mozstdstaging-track-digest256

--- a/prod.ini
+++ b/prod.ini
@@ -161,15 +161,6 @@ output=except-flashinfobar-digest256
 s3_key=plugin-blocklist/except-flashinfobar-digest256
 blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashinfobar.txt
 
-[staging-tracking-protection-standard]
-output=mozstdstaging-track-digest256
-s3_key=tracking/mozstdstaging-track-digest256
-
-[staging-tracking-protection-full]
-categories=Advertising|Analytics|Social|Content
-output=mozfullstaging-track-digest256
-s3_key=tracking/mozfullstaging-track-digest256
-
 [tracking-protection-base-fingerprinting]
 categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256

--- a/stage.ini
+++ b/stage.ini
@@ -169,15 +169,6 @@ output=except-flashinfobar-digest256
 s3_key=plugin-blocklist/except-flashinfobar-digest256
 blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashinfobar.txt
 
-[staging-tracking-protection-standard]
-output=mozstdstaging-track-digest256
-s3_key=tracking/mozstdstaging-track-digest256
-
-[staging-tracking-protection-full]
-categories=Advertising|Analytics|Social|Content
-output=mozfullstaging-track-digest256
-s3_key=tracking/mozfullstaging-track-digest256
-
 [tracking-protection-base-fingerprinting]
 categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256

--- a/stage.ini
+++ b/stage.ini
@@ -114,11 +114,6 @@ output=google-trackwhite-digest256
 s3_key=entity/google-trackwhite-digest256
 versioning_needed=true
 
-[entity-whitelist-testing]
-entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-test-lists/master/trackwhite.json
-output=moztestpub-trackwhite-digest256
-s3_key=entitytest/moztestpub-trackwhite-digest256
-
 [tracking-protection-standard]
 output=mozstd-track-digest256
 s3_key=tracking/mozstd-track-digest256

--- a/stage.ini
+++ b/stage.ini
@@ -169,11 +169,6 @@ output=except-flashinfobar-digest256
 s3_key=plugin-blocklist/except-flashinfobar-digest256
 blocklist=https://raw.githubusercontent.com/mozilla-services/shavar-plugin-blocklist/master/flashinfobar.txt
 
-[staging-entity-whitelist]
-entity_url=https://raw.githubusercontent.com/mozilla-services/shavar-staging-lists/master/disconnect-entitylist.json
-output=mozstdstaging-trackwhite-digest256
-s3_key=entity/mozstdstaging-trackwhite-digest256
-
 [staging-tracking-protection-standard]
 output=mozstdstaging-track-digest256
 s3_key=tracking/mozstdstaging-track-digest256


### PR DESCRIPTION
# About this PR
As mentioned in the main issue https://github.com/mozilla-services/shavar-list-creation/issues/126 we are removing the staging and testing lists.

# Acceptance Criteria
- [ ] Remove staging list configs https://github.com/mozilla-services/shavar-staging-lists/issues/3
- [ ] Remove testing list configs https://github.com/mozilla-services/shavar-test-lists/issues/13
- [ ] Remove `[staging-tracking-protection-standard]` and `[staging-tracking-protection-full]` as they are duplicates of `[tracking-protection-standard]` and `[tracking-protection-full]`