### PR TITLE
Enable rs uploads in prod

### DIFF
--- a/prod.ini
+++ b/prod.ini
@@ -3,6 +3,14 @@ default_disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar
 s3_bucket=net-mozaws-prod-shavar
 s3_upload=true
 
+# Enable RS uploads for Nightly only. The shavar-list-creation code handles switching remote_settings_upload to false for versioned lists
+remote_settings_upload=true
+remote_settings_bucket=main-workspace
+remote_settings_collection=tracking-protection-lists
+remote_settings_url=%(SHAVAR_REMOTE_SETTINGS_URL)s
+remote_settings_username=%(SHAVAR_REMOTE_SETTINGS_USERNAME)s
+remote_settings_password=%(SHAVAR_REMOTE_SETTINGS_PASSWORD)s
+
 # DNT="", all categories except content category
 [tracking-protection-base]
 output=base-track-digest256


### PR DESCRIPTION
## Description

Enable rs uploads in prod. Fixes #73 

### Note

As the shavar-list-creation ./lists2safebrowsing code disables rs uploads for versioned lists, enabling rs_upload in prod right now only allows uploads for one unversioned version of the list, which is served to the latest Nightly version.